### PR TITLE
fix isURL function by checking url scheme

### DIFF
--- a/cmd/sandglass/cmd/root.go
+++ b/cmd/sandglass/cmd/root.go
@@ -203,6 +203,9 @@ func initConfig() {
 }
 
 func isURL(u string) bool {
-	_, err := url.ParseRequestURI(u)
-	return err == nil
+	p, err := url.Parse(u)
+	if err != nil {
+		return false
+	}
+	return p.Scheme == "http" || p.Scheme == "https"
 }


### PR DESCRIPTION
Previously isURL was returning true if the string is an absolute path like "/data/config.yaml". Example comparison is at playground [https://play.golang.org/p/zNy7Oy0X2T](https://play.golang.org/p/zNy7Oy0X2T)